### PR TITLE
Add willSet / didSet support to Observable (kind of)

### DIFF
--- a/ReactiveKit/Observable/Observable.swift
+++ b/ReactiveKit/Observable/Observable.swift
@@ -28,9 +28,17 @@ public protocol ObservableType: StreamType {
 }
 
 public final class Observable<Value>: ActiveStream<Value>, ObservableType {
+  public typealias WillSetBlockType = (value: Value, newValue: Value) -> ()
+  private var willSetBlock : WillSetBlockType?
+  public typealias DidSetBlockType = (oldValue: Value, value: Value) -> ()
+  private var didSetBlock : DidSetBlockType?
   
   public var value: Value {
+    willSet {
+      willSetBlock?(value: value, newValue:newValue)
+    }
     didSet {
+      didSetBlock?(oldValue: oldValue, value:value)
       super.next(value)
     }
   }
@@ -49,4 +57,15 @@ public final class Observable<Value>: ActiveStream<Value>, ObservableType {
     observer(value)
     return disposable
   }
+
+  public func willSet(willSetBlock: WillSetBlockType?) -> Observable<Value> {
+    self.willSetBlock = willSetBlock
+    return self
+  }
+
+  public func didSet(didSetBlock: DidSetBlockType?) -> Observable<Value> {
+    self.didSetBlock = didSetBlock
+    return self
+  }
+
 }

--- a/ReactiveKit/ObservableCollection/ObservableCollection.swift
+++ b/ReactiveKit/ObservableCollection/ObservableCollection.swift
@@ -35,7 +35,19 @@ public protocol ObservableCollectionType: CollectionType, StreamType {
 
 public final class ObservableCollection<Collection: CollectionType>: ActiveStream<ObservableCollectionEvent<Collection>>, ObservableCollectionType {
 
-  private var collectionEvent: ObservableCollectionEvent<Collection>! = nil
+  public typealias WillSetBlockType = (value: Collection, newValue: Collection) -> ()
+  private var willSetBlock : WillSetBlockType?
+  public typealias DidSetBlockType = (oldValue: Collection, value: Collection) -> ()
+  private var didSetBlock : DidSetBlockType?
+
+  private var collectionEvent: ObservableCollectionEvent<Collection>! = nil {
+    willSet {
+      willSetBlock?(value: collection, newValue:newValue.collection)
+    }
+    didSet {
+      didSetBlock?(oldValue: oldValue.collection, value: collection)
+    }
+  }
 
   public var collection: Collection {
     return collectionEvent.collection
@@ -59,6 +71,16 @@ public final class ObservableCollection<Collection: CollectionType>: ActiveStrea
     let disposable = super.observe(on: context, observer: observer)
     observer(collectionEvent)
     return disposable
+  }
+
+  public func willSet(willSetBlock: WillSetBlockType?) -> ObservableCollection<Collection> {
+    self.willSetBlock = willSetBlock
+    return self
+  }
+    
+  public func didSet(didSetBlock: DidSetBlockType?) -> ObservableCollection<Collection> {
+    self.didSetBlock = didSetBlock
+    return self
   }
   
   // MARK: CollectionType conformance


### PR DESCRIPTION
This way a model can use willSet / didSet on it's own Observables:

```swift
    let someValue = Observable<Int?>(nil)
        .willSet{
            value, newValue in
            print("CURRENT: \(value) -> NEW: \(newValue)")
        }
        .didSet{
            oldValue, value in
            print("OLD: \(oldValue) -> CURRENT: \(value)")
        }
```