### PR TITLE
Added 'moveItemAtIndex(toIndex:)' to 'ObservableCollection+Array'

### DIFF
--- a/ReactiveKit/ObservableCollection/ObservableCollection+Array.swift
+++ b/ReactiveKit/ObservableCollection/ObservableCollection+Array.swift
@@ -44,6 +44,16 @@ extension ObservableCollectionType where Collection == Array<Element> {
     new.insertContentsOf(newElements, at: index)
     next(ObservableCollectionEvent(collection: new, inserts: Array(index..<index+newElements.count), deletes: [], updates: []))
   }
+  
+  /// Move the element at index `i` to index `toIndex`.
+  public mutating func moveItemAtIndex(fromIndex: Int, toIndex: Int) {
+    let item = collection[fromIndex]
+    var new = collection
+    new.removeAtIndex(fromIndex)
+    new.insert(item, atIndex: toIndex)
+    let updates = Array(min(fromIndex, toIndex)...max(fromIndex, toIndex))
+    next(ObservableCollectionEvent(collection: new, inserts: [], deletes: [], updates: updates))
+  }
 
   /// Remove and return the element at index i.
   public mutating func removeAtIndex(index: Int) -> Collection.Generator.Element {

--- a/ReactiveKitTests/ObservableCollectionSpec.swift
+++ b/ReactiveKitTests/ObservableCollectionSpec.swift
@@ -66,6 +66,48 @@ class ObservableCollectionSpec: QuickSpec {
             expect(observedEvents[1]).to(equal(ObservableCollectionEvent(collection: [1, 10, 11, 2, 3], inserts: [1, 2], deletes: [], updates: [])))
           }
         }
+        
+        describe("moveItemAtIndex") {
+          describe("fromFirstToLast") {
+            beforeEach {
+              observableCollection.moveItemAtIndex(0, toIndex: 2)
+            }
+            
+            it("movesAndUpdatesAllIndexes") {
+              expect(observedEvents[1]).to(equal(ObservableCollectionEvent(collection: [2, 3, 1], inserts: [], deletes: [], updates: [0, 1, 2])))
+            }
+          }
+          
+          describe("fromFirstToSecond") {
+            beforeEach {
+              observableCollection.moveItemAtIndex(0, toIndex: 1)
+            }
+            
+            it("movesAndUpdatesAffectedIndexes") {
+              expect(observedEvents[1]).to(equal(ObservableCollectionEvent(collection: [2, 1, 3], inserts: [], deletes: [], updates: [0, 1])))
+            }
+          }
+          
+          describe("fromLastToFirst") {
+            beforeEach {
+              observableCollection.moveItemAtIndex(2, toIndex: 0)
+            }
+            
+            it("movesAndUpdatesAllIndexes") {
+              expect(observedEvents[1]).to(equal(ObservableCollectionEvent(collection: [3, 1, 2], inserts: [], deletes: [], updates: [0, 1, 2])))
+            }
+          }
+          
+          describe("fromLastToSecond") {
+            beforeEach {
+              observableCollection.moveItemAtIndex(2, toIndex: 1)
+            }
+            
+            it("movesAndUpdatesAffectedIndexes") {
+              expect(observedEvents[1]).to(equal(ObservableCollectionEvent(collection: [1, 3, 2], inserts: [], deletes: [], updates: [1, 2])))
+            }
+          }
+        }
 
         describe("removeAtIndex") {
           beforeEach {


### PR DESCRIPTION
I noticed that there was no good way to implement moving items in an `ObservableCollection<Array>`. Trying to do this by copying the collection, making the changes, and calling `replace(newCollection)` was generating an incorrect diff. Since, `diff` is only looking for inserts and deletes, but updates are not accounted for.

It might be worthwhile to create an issue that address this shortcoming in diff calculation, but in the mean time, this will work.

Bonus: It's also fully unit tested!