### PR TITLE
Fix areDistinct closure for OptionalType

### DIFF
--- a/Sources/RawStream.swift
+++ b/Sources/RawStream.swift
@@ -457,7 +457,7 @@ public extension RawStreamType where Event.Element: OptionalType, Event.Element.
         return true
       case (.Some, .None):
         return true
-      case (.Some(let old), .Some(let new)) where old == new:
+      case (.Some(let old), .Some(let new)) where old != new:
         return true
       default:
         return false


### PR DESCRIPTION
`areDistinct` closure in `RawStream.distinct()` seems return wrong value.

Change to return true when element is not equal.