### PR TITLE
Fix scan to emit initial value

### DIFF
--- a/Sources/RawStream.swift
+++ b/Sources/RawStream.swift
@@ -173,6 +173,7 @@ public extension RawStreamType {
   public func scan<U: EventType>(initial: U, _ combine: (U, Event) -> U) -> RawStream<U> {
     return RawStream<U> { observer in
       var accumulator = initial
+      observer.observer(accumulator)
       return self.observe { event in
         accumulator = combine(accumulator, event)
         observer.observer(accumulator)
@@ -794,10 +795,7 @@ public extension RawStreamType {
   /// Reduce stream events to a single event by applying given function on each emission.
   @warn_unused_result
   public func reduce<U: EventType>(initial: U, _ combine: (U, Event) -> U) -> RawStream<U> {
-    return RawStream<U> { observer in
-      observer.observer(initial)
-      return self.scan(initial, combine).observe(observer.observer)
-      }.takeLast()
+    return scan(initial, combine).takeLast()
   }
 }
 

--- a/Tests/OperationTests.swift
+++ b/Tests/OperationTests.swift
@@ -77,7 +77,7 @@ class OperatorsTests: XCTestCase {
   func testScan() {
     let operation = Operation<Int, TestError>.sequence([1, 2, 3])
     let scanned = operation.scan(0, +)
-    scanned.expectNext([1, 3, 6])
+    scanned.expectNext([0, 1, 3, 6])
   }
 
   func testToOperation() {

--- a/Tests/StreamTests.swift
+++ b/Tests/StreamTests.swift
@@ -68,7 +68,7 @@ class StreamTests: XCTestCase {
   func testScan() {
     let stream = Stream.sequence([1, 2, 3])
     let scanned = stream.scan(0, +)
-    scanned.expectNext([1, 3, 6])
+    scanned.expectNext([0, 1, 3, 6])
   }
 
   func testToOperation() {


### PR DESCRIPTION
Current `scan` and `reduce` are working inconsistently when the original stream is empty, i.e.

- `scan` emits no value at all.
- `reduce` emits initial value.

(I think `scan` is running aggregate, so it should include `reduce` value, which is last aggregate value. If not, please correct me!)

When initial value is given, I think it should be emitted as first accumulator value.

As written at [Aggregation](http://www.introtorx.com/content/v1.0.10621.0/07_Aggregation.html#Scan),

> It is probably worth pointing out that you use Scan with TakeLast() to produce Aggregate.
> ```
> source.Aggregate(0, (acc, current) => acc + current);
> //is equivalent to 
> source.Scan(0, (acc, current) => acc + current).TakeLast();
> ```

`reduce` should be equal to `return scan(initial, combine).takeLast()`.

We need this characteristic for consistence between empty and non-empty stream.
For example, think about the case showing running sum of integer stream in UI.
If `scan` emit no value, we should manually update UI with zero, which seems very awkward.