### PR TITLE
Update `_value` when `on` is called in Property

### DIFF
--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -54,6 +54,9 @@ public final class Property<T>: PropertyType, StreamType, SubjectType {
   }
 
   public func on(event: StreamEvent<T>) {
+    if let element = event.element {
+      self._value = element
+    }
     subject.on(event)
   }
 


### PR DESCRIPTION
Keeping `Property`'s `_value` same with the last emitted value seems more consistent.