### PR TITLE
Removed `print("deinit")` call.

### DIFF
--- a/Sources/Foundation.swift
+++ b/Sources/Foundation.swift
@@ -184,7 +184,6 @@ public class RKKeyValueStream<T>: NSObject, StreamType {
 
   deinit {
     subject.completed()
-    print("deinit")
   }
 
   public override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {


### PR DESCRIPTION
The message "deinit" was being printed in the debugger multiple times. I assume this call was used for debugging in the past. If it is still needed, then leave it in, otherwise let's free up some space on our debugger consoles!