### PR TITLE
Change isUpdating guard to assertionFailure instead of silently dropping events

### DIFF
--- a/Sources/Subjects.swift
+++ b/Sources/Subjects.swift
@@ -67,7 +67,7 @@ public final class PublishSubject<E: EventType>: ObserverRegister<E>, RawSubject
   public func on(event: E) {
     guard !completed else { return }
     lock.lock(); defer { lock.unlock() }
-    guard !isUpdating else { return }
+    guard !isUpdating else { assertionFailure("Cannot dispatch within update cycle"); return }
     isUpdating = true
     completed = event.isTermination
     observers.forEach { $0(event) }
@@ -97,7 +97,7 @@ public final class ReplaySubject<E: EventType>: ObserverRegister<E>, RawSubjectT
   public func on(event: E) {
     guard !completed else { return }
     lock.lock(); defer { lock.unlock() }
-    guard !isUpdating else { return }
+    guard !isUpdating else { assertionFailure("Cannot dispatch within update cycle"); return }
     isUpdating = true
     buffer.append(event)
     buffer = buffer.suffix(bufferSize)
@@ -134,7 +134,7 @@ public final class ReplayOneSubject<E: EventType>: ObserverRegister<E>, RawSubje
   public func on(event: E) {
     guard !completed else { return }
     lock.lock(); defer { lock.unlock() }
-    guard !isUpdating else { return }
+    guard !isUpdating else { assertionFailure("Cannot dispatch within update cycle"); return }
     isUpdating = true
     if event.isTermination {
       self.terminatingEvent = event


### PR DESCRIPTION
This is just a little debugging aid, it took me a while to realize that some of the events are dropped, saying that https://github.com/ReactiveKit/ReactiveKit/commit/1fae49b15bc46137334f9d44f217afbd909ecc3a wasn't adding tests so not sure is it safe to merge
