### PR TITLE
Add @escaping to function parameters because it is no longer implicit

### DIFF
--- a/ReactiveKit/Foundation.swift
+++ b/ReactiveKit/Foundation.swift
@@ -157,7 +157,7 @@ public class RKKeyValueStream<T>: NSObject, StreamType {
   fileprivate var context = 0
   fileprivate var keyPath: String
   fileprivate var options: NSKeyValueObservingOptions
-  fileprivate let transform: @escaping (AnyObject?) -> T?
+  fileprivate let transform: (AnyObject?) -> T?
   fileprivate let subject: AnySubject<StreamEvent<T>>
   fileprivate var numberOfObservers: Int = 0
 

--- a/ReactiveKit/ProtocolProxy.swift
+++ b/ReactiveKit/ProtocolProxy.swift
@@ -36,7 +36,7 @@ public class ProtocolProxy: RKProtocolProxyBase {
     return invokers[selector] != nil
   }
 
-  public override func invoke(_ selector: Selector, argumentExtractor: @escaping (Int, UnsafeMutableRawPointer?) -> Swift.Void, setReturnValue: (@escaping (UnsafeMutableRawPointer?) -> Swift.Void)? = nil) {
+  public override func invoke(_ selector: Selector, argumentExtractor: @escaping (Int, UnsafeMutableRawPointer?) -> Swift.Void, setReturnValue: ((UnsafeMutableRawPointer?) -> Swift.Void)? = nil) {
     guard let invoker = invokers[selector] else { return }
     invoker(argumentExtractor, setReturnValue)
   }

--- a/Sources/Operation.swift
+++ b/Sources/Operation.swift
@@ -755,7 +755,7 @@ extension OperationType {
 
   /// Set the execution context in which to execute the operation (i.e. in which to run
   /// the operation's producer).
-  public func executeIn(_ context: ExecutionContext) -> Operation<Element, ErrorType> {
+  public func executeIn(_ context: @escaping ExecutionContext) -> Operation<Element, ErrorType> {
     return lift { $0.executeIn(context) }
   }
 
@@ -807,7 +807,7 @@ extension OperationType {
   }
 
   /// Set the execution context in which to dispatch events (i.e. in which to run observers).
-  public func observeIn(_ context: ExecutionContext) -> Operation<Element, ErrorType> {
+  public func observeIn(_ context: @escaping ExecutionContext) -> Operation<Element, ErrorType> {
     return lift { $0.observeIn(context) }
   }
 

--- a/Sources/RawStream.swift
+++ b/Sources/RawStream.swift
@@ -622,7 +622,7 @@ public extension RawStreamType {
 
   /// Set the execution context in which to execute the stream (i.e. in which to run
   /// stream's producer).
-  public func executeIn(_ context: ExecutionContext) -> RawStream<Event> {
+  public func executeIn(_ context: @escaping ExecutionContext) -> RawStream<Event> {
     return RawStream { observer in
       let serialDisposable = SerialDisposable(otherDisposable: nil)
       context {
@@ -649,7 +649,7 @@ public extension RawStreamType {
 
   /// Set the execution context in which to dispatch events (i.e. in which to run
   /// observers).
-  public func observeIn(_ context: ExecutionContext) -> RawStream<Event> {
+  public func observeIn(_ context: @escaping ExecutionContext) -> RawStream<Event> {
     return RawStream { observer in
       return self.observe { event in
         context {

--- a/Sources/Stream.swift
+++ b/Sources/Stream.swift
@@ -557,7 +557,7 @@ extension StreamType {
 
   /// Set the execution context in which to execute the stream (i.e. in which to run
   /// the stream's producer).
-  public func executeIn(_ context: ExecutionContext) -> Stream<Element> {
+  public func executeIn(_ context: @escaping ExecutionContext) -> Stream<Element> {
     return lift { $0.executeIn(context) }
   }
 
@@ -603,7 +603,7 @@ extension StreamType {
   }
 
   /// Set the execution context in which to dispatch events (i.e. in which to run observers).
-  public func observeIn(_ context: ExecutionContext) -> Stream<Element> {
+  public func observeIn(_ context: @escaping ExecutionContext) -> Stream<Element> {
     return lift { $0.observeIn(context) }
   }
 


### PR DESCRIPTION
This is as per swift proposal [SE-0103](https://github.com/apple/swift-evolution/blob/master/proposals/0103-make-noescape-default.md) and was basically done via xcode's code suggestion.

Not sure on protocol but figured I would fix for anyone else at least, happy to update anything necessary to get this mergable.
