### PR TITLE
Fix multiple connect() not to call multiple observe()

### DIFF
--- a/Sources/Bindable.swift
+++ b/Sources/Bindable.swift
@@ -54,7 +54,7 @@ extension BindableProtocol where Self: SignalProtocol {
   /// Establish a two-way binding between the source and the bindable
   /// and return a disposable that can cancel binding.
   @discardableResult
-  public func bidirectionalBind<B: BindableProtocol >(to bindable: B) -> Disposable where B: SignalProtocol, B.Element == Element, B.Error == Error {
+  public func bidirectionalBind<B: BindableProtocol & SignalProtocol>(to bindable: B) -> Disposable where B.Element == Element, B.Error == Error {
     let d1 = self.bind(to: bindable)
     let d2 = bindable.bind(to: self)
     return CompositeDisposable([d1, d2])

--- a/Sources/Connectable.swift
+++ b/Sources/Connectable.swift
@@ -49,11 +49,11 @@ public final class ConnectableSignal<O: SignalProtocol>: ConnectableSignalProtoc
   /// Start the signal.
   public func connect() -> Disposable {
     return lock.atomic {
-      if let connectionDisposable = connectionDisposable {
-        return connectionDisposable
-      } else {
-        return source.observe(with: subject.on)
+      if connectionDisposable == nil {
+        connectionDisposable = source.observe(with: subject.on)
       }
+      
+      return connectionDisposable!
     }
   }
 

--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -100,7 +100,7 @@ public class DeinitDisposable: Disposable {
   }
 
   deinit {
-    otherDisposable?.dispose()
+    dispose()
   }
 }
 

--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -31,7 +31,7 @@ public protocol PropertyProtocol {
 }
 
 /// Represents mutable state that can be observed as a signal of events.
-public class Property<Value>: PropertyProtocol, SignalProtocol, SubjectProtocol, BindableProtocol {
+public class Property<Value>: PropertyProtocol, SubjectProtocol, BindableProtocol {
 
   private var _value: Value
   private let subject = PublishSubject<Value, NoError>()

--- a/Sources/SignalProtocol.swift
+++ b/Sources/SignalProtocol.swift
@@ -878,7 +878,7 @@ extension SignalProtocol {
     }
   }
 
-  /// Emit default element is signal completes without emitting any element.
+  /// Emit default element if signal completes without emitting any element.
   public func defaultIfEmpty(_ element: Element) -> Signal<Element, Error> {
     return Signal { observer in
       var didEmitNonTerminal = false


### PR DESCRIPTION
Current `ConnectableSignal.connect()` introduces multiple observation between `source` and `subject` so that event replicates multiple times.

Fix to `observe` only once.