### PR TITLE
Update dispose method syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ class X {
     ...
     aSignal.observeNext { _ in
       ...
-    }.disposeIn(disposeBag)
+    }.dispose(in: disposeBag)
   }
 }
 ```

--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -176,7 +176,7 @@ public final class DisposeBag: Disposable {
 }
 
 public extension Disposable {
-  public func disposeIn(_ disposeBag: DisposeBag) {
+  public func dispose(in disposeBag: DisposeBag) {
     disposeBag.add(disposable: self)
   }
 }


### PR DESCRIPTION
Based on the Swift 3.0 API Design Guidelines a preposition should go inside the parentheses as an argument label.