### PR TITLE
Import Foundation into source files that reference NSRecursiveLock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode8.2
 
 script:
-  - xcodebuild -workspace ReactiveKit.xcworkspace -scheme ReactiveKit-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.3' test
+  - set -o pipefail && xcodebuild -project ReactiveKit.xcodeproj -scheme ReactiveKit-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.0' test | xcpretty
+  - set -o pipefail && swift build
+  - set -o pipefail && swift test
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Sources/Connectable.swift
+++ b/Sources/Connectable.swift
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 //
 
+import Foundation
+
 /// Represents a signal that is started by calling `connect` on it.
 public protocol ConnectableSignalProtocol: SignalProtocol {
 

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 //
 
+import Foundation
+
 /// Represents a type that receives events.
 public protocol ObserverProtocol {
 


### PR DESCRIPTION
This PR resolves an issue where Swift cannot resolve `NSRecursiveLock` due to Foundation not being imported into a couple of source files.

I've seen similar issues to #111 tonight while working on Bond with Swift Package Manager:

```
/Users/tonyarnold/Documents/Repositories/Bond/Packages/ReactiveKit-3.1.1/Sources/Connectable.swift:36:22: error: use of unresolved identifier 'NSRecursiveLock'
  private let lock = NSRecursiveLock()
                     ^~~~~~~~~~~~~~~
/Users/tonyarnold/Documents/Repositories/Bond/Packages/ReactiveKit-3.1.1/Sources/Observer.swift:60:22: error: use of unresolved identifier 'NSRecursiveLock'
  private let lock = NSRecursiveLock(name: "com.reactivekit.signal.atomicobserver")
                     ^~~~~~~~~~~~~~~
/Users/tonyarnold/Documents/Repositories/Bond/Packages/ReactiveKit-3.1.1/Sources/Observer.swift:60:22: error: use of unresolved identifier 'NSRecursiveLock'
  private let lock = NSRecursiveLock(name: "com.reactivekit.signal.atomicobserver")
                     ^~~~~~~~~~~~~~~
/Users/tonyarnold/Documents/Repositories/Bond/Packages/ReactiveKit-3.1.1/Sources/Observer.swift:60:22: error: use of unresolved identifier 'NSRecursiveLock'
  private let lock = NSRecursiveLock(name: "com.reactivekit.signal.atomicobserver")
                     ^~~~~~~~~~~~~~~
/Users/tonyarnold/Documents/Repositories/Bond/Packages/ReactiveKit-3.1.1/Sources/Observer.swift:60:22: error: use of unresolved identifier 'NSRecursiveLock'
  private let lock = NSRecursiveLock(name: "com.reactivekit.signal.atomicobserver")
                     ^~~~~~~~~~~~~~~
/Users/tonyarnold/Documents/Repositories/Bond/Packages/ReactiveKit-3.1.1/Sources/Observer.swift:60:22: error: use of unresolved identifier 'NSRecursiveLock'
  private let lock = NSRecursiveLock(name: "com.reactivekit.signal.atomicobserver")
                     ^~~~~~~~~~~~~~~
/Users/tonyarnold/Documents/Repositories/Bond/Packages/ReactiveKit-3.1.1/Sources/Observer.swift:60:22: error: use of unresolved identifier 'NSRecursiveLock'
  private let lock = NSRecursiveLock(name: "com.reactivekit.signal.atomicobserver")
                     ^~~~~~~~~~~~~~~
/Users/tonyarnold/Documents/Repositories/Bond/Packages/ReactiveKit-3.1.1/Sources/Observer.swift:60:22: error: use of unresolved identifier 'NSRecursiveLock'
  private let lock = NSRecursiveLock(name: "com.reactivekit.signal.atomicobserver")
                     ^~~~~~~~~~~~~~~
<unknown>:0: error: build had 1 command failures
error: exit(1): /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-build-tool -f /Users/tonyarnold/Documents/Repositories/Bond/.build/debug.yaml
```