### PR TITLE
Add parameter to allow recover(with: …) to continue without completing

### DIFF
--- a/Sources/SignalProtocol.swift
+++ b/Sources/SignalProtocol.swift
@@ -349,7 +349,7 @@ public extension SignalProtocol {
   }
 
   /// Recovers the signal by propagating default element if error happens.
-  public func recover(with element: Element) -> Signal<Element, NoError> {
+  public func recover(with element: Element, completeOnError: Bool = true) -> Signal<Element, NoError> {
     return Signal { observer in
       return self.observe { event in
         switch event {
@@ -357,7 +357,9 @@ public extension SignalProtocol {
           observer.next(element)
         case .failed:
           observer.next(element)
-          observer.completed()
+          if completeOnError {
+            observer.completed()
+          }
         case .completed:
           observer.completed()
         }

--- a/Tests/ReactiveKitTests/SignalTests.swift
+++ b/Tests/ReactiveKitTests/SignalTests.swift
@@ -132,7 +132,13 @@ class SignalTests: XCTestCase {
   func testRecover() {
     let operation = Signal<Int, TestError>.failed(.Error)
     let signal = operation.recover(with: 1)
-    signal.expectNext([1])
+    signal.expect([.next(1), .completed])
+  }
+
+  func testRecoverAndContinueAfterFailure() {
+    let operation = Signal<Int, TestError>.failed(.Error)
+    let signal = operation.recover(with: 1, completeOnError: false)
+    signal.expect([.next(1)])
   }
 
   func testWindow() {


### PR DESCRIPTION
This PR adds a parameter to SignalProtocol's `recover(with element: Element)` method, which allows the API consumer to decide whether the recovery should complete the stream, or allow it to continue afterward. 

This has no impact on existing use of the API, as the default value for the `completeOnError` argument is `true`, maintaining existing behaviour. 

I'm not 100% sure how to test this properly: I could use some feedback on what I've included in this PR.

