### PR TITLE
Replace old names with new one.

### DIFF
--- a/Playground.playground/Contents.swift
+++ b/Playground.playground/Contents.swift
@@ -6,7 +6,7 @@ import PlaygroundSupport
 var p: Property! = Property(1)
 weak var wp: Property<Int>? = p
 
-Signal1<Double>.interval(1, queue: .main).map { $0 }.debug("test signal").bind(to: p)
+SafeSignal<Double>.interval(1, queue: .main).map { $0 }.debug("test signal").bind(to: p)
 
 DispatchQueue.main.after(when: 3.3) {
   p = nil

--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -199,7 +199,7 @@ public final class DisposeBag: DisposeBagProtocol {
     disposables.removeAll()
   }
 
-  public var deallocated: Signal1<Void> {
+  public var deallocated: SafeSignal<Void> {
     lock.lock()
     if subject == nil {
       subject = ReplayOneSubject()

--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -60,13 +60,13 @@ public struct AnyObserver<Element, Error: Swift.Error>: ObserverProtocol {
 /// Observer that ensures events are sent atomically.
 public class AtomicObserver<Element, Error: Swift.Error>: ObserverProtocol {
 
-  private let observer: (Event<Element, Error>) -> Void
+  private let observer: Observer<Element, Error>
   private let disposable: Disposable
   private let lock = NSRecursiveLock(name: "com.reactivekit.signal.atomicobserver")
   private var terminated = false
 
   /// Creates an observer that wraps given closure.
-  public init(disposable: Disposable, observer: @escaping (Event<Element, Error>) -> Void) {
+  public init(disposable: Disposable, observer: @escaping Observer<Element, Error>) {
     self.disposable = disposable
     self.observer = observer
   }

--- a/Sources/Subjects.swift
+++ b/Sources/Subjects.swift
@@ -53,13 +53,13 @@ open class Subject<Element, Error: Swift.Error>: SubjectProtocol {
     forEachObserver { $0(event) }
   }
 
-  open func observe(with observer: @escaping (Event<Element, Error>) -> Void) -> Disposable {
+  open func observe(with observer: @escaping Observer<Element, Error>) -> Disposable {
     lock.lock(); defer { lock.unlock() }
     willAdd(observer: observer)
     return add(observer: observer)
   }
 
-  open func willAdd(observer: @escaping (Event<Element, Error>) -> Void) {
+  open func willAdd(observer: @escaping Observer<Element, Error>) {
   }
 
   private func add(observer: @escaping Observer<Element, Error>) -> Disposable {
@@ -115,7 +115,7 @@ public final class ReplaySubject<Element, Error: Swift.Error>: Subject<Element, 
     super.send(event)
   }
 
-  public override func willAdd(observer: @escaping (Event<Element, Error>) -> Void) {
+  public override func willAdd(observer: @escaping Observer<Element, Error>) {
     buffer.forEach(observer)
   }
 }
@@ -135,7 +135,7 @@ public final class ReplayOneSubject<Element, Error: Swift.Error>: Subject<Elemen
     super.send(event)
   }
 
-  public override func willAdd(observer: @escaping (Event<Element, Error>) -> Void) {
+  public override func willAdd(observer: @escaping Observer<Element, Error>) {
     if let event = lastEvent {
       observer(event)
     }
@@ -148,8 +148,8 @@ public final class ReplayOneSubject<Element, Error: Swift.Error>: Subject<Elemen
 
 @available(*, deprecated, message: "All subjects now inherit 'Subject' that can be used in place of 'AnySubject'.")
 public final class AnySubject<Element, Error: Swift.Error>: SubjectProtocol {
-  private let baseObserve: (@escaping (Event<Element, Error>) -> Void) -> Disposable
-  private let baseOn: (Event<Element, Error>) -> Void
+  private let baseObserve: (@escaping Observer<Element, Error>) -> Disposable
+  private let baseOn: Observer<Element, Error>
 
   public let disposeBag = DisposeBag()
 
@@ -162,7 +162,7 @@ public final class AnySubject<Element, Error: Swift.Error>: SubjectProtocol {
     return baseOn(event)
   }
 
-  public func observe(with observer: @escaping (Event<Element, Error>) -> Void) -> Disposable {
+  public func observe(with observer: @escaping Observer<Element, Error>) -> Disposable {
     return baseObserve(observer)
   }
 }

--- a/Tests/ReactiveKitTests/PropertyTests.swift
+++ b/Tests/ReactiveKitTests/PropertyTests.swift
@@ -38,7 +38,7 @@ class PropertyTests: XCTestCase {
 
     property.value = 5
     property.value = 10
-    Signal1.sequence([20, 30]).bind(to: property)
+    SafeSignal.sequence([20, 30]).bind(to: property)
     property.value = 40
 
     weak var weakProperty = property
@@ -66,7 +66,7 @@ class PropertyTests: XCTestCase {
 
     property.value = 5
     property.value = 10
-    Signal1.sequence([20, 30]).bind(to: property)
+    SafeSignal.sequence([20, 30]).bind(to: property)
     property.value = 40
 
     XCTAssert(readOnlyView.value == 40)


### PR DESCRIPTION
Replace verbose type signature where Observer<Element, Error> fits in.
Replace Signal1 with SafeSignal.