### PR TITLE
Complete zip() when any of its input signal completes.

### DIFF
--- a/Sources/SignalProtocol.swift
+++ b/Sources/SignalProtocol.swift
@@ -1450,7 +1450,7 @@ extension SignalProtocol {
       }
 
       func completeIfPossible() {
-        if completions.me && completions.other {
+        if completions.me || completions.other {
           observer.completed()
         }
       }

--- a/Sources/SignalProtocol.swift
+++ b/Sources/SignalProtocol.swift
@@ -1450,7 +1450,7 @@ extension SignalProtocol {
       }
 
       func completeIfPossible() {
-        if completions.me || completions.other {
+        if (buffers.my.isEmpty && completions.me) || (buffers.other.isEmpty && completions.other) {
           observer.completed()
         }
       }
@@ -1460,13 +1460,13 @@ extension SignalProtocol {
         switch event {
         case .next(let element):
           buffers.my.append(element)
-          dispatchIfPossible()
         case .failed(let error):
           observer.failed(error)
         case .completed:
           completions.me = true
-          completeIfPossible()
         }
+        dispatchIfPossible()
+        completeIfPossible()
       }
 
       compositeDisposable += other.observe { event in
@@ -1474,13 +1474,13 @@ extension SignalProtocol {
         switch event {
         case .next(let element):
           buffers.other.append(element)
-          dispatchIfPossible()
         case .failed(let error):
           observer.failed(error)
         case .completed:
           completions.other = true
-          completeIfPossible()
         }
+        dispatchIfPossible()
+        completeIfPossible()
       }
 
       return compositeDisposable

--- a/Tests/ReactiveKitTests/Helpers.swift
+++ b/Tests/ReactiveKitTests/Helpers.swift
@@ -57,7 +57,7 @@ extension SignalProtocol {
     let _ = observe { event in
       receivedEvents.append(event)
       if eventsToProcess.count == 0 {
-        XCTFail("Got more events then expected.")
+        XCTFail("Got more events than expected.")
         return
       }
       let expected = eventsToProcess.removeFirst()

--- a/Tests/ReactiveKitTests/SignalTests.swift
+++ b/Tests/ReactiveKitTests/SignalTests.swift
@@ -281,7 +281,18 @@ class SignalTests: XCTestCase {
     let operationA = Signal<Int, TestError>.sequence([1, 2, 3])
     let operationB = Signal<String, TestError>.sequence(["A", "B"])
     let combined = operationA.zip(with: operationB).map { "\($0)\($1)" }
-    combined.expectNext(["1A", "2B"])
+    let exp = expectation(description: "completed")
+    combined.expectNext(["1A", "2B"], expectation: exp)
+    waitForExpectations(timeout: 1, handler: nil)
+  }
+  
+  func testZipWithWhenNotComplete() {
+    let operationA = Signal<Int, TestError>.sequence([1, 2, 3]).ignoreTerminal()
+    let operationB = Signal<String, TestError>.sequence(["A", "B"])
+    let combined = operationA.zip(with: operationB).map { "\($0)\($1)" }
+    let exp = expectation(description: "completed")
+    combined.expectNext(["1A", "2B"], expectation: exp)
+    waitForExpectations(timeout: 1, handler: nil)
   }
 
   func testFlatMapError() {


### PR DESCRIPTION
Fix for https://github.com/ReactiveKit/ReactiveKit/issues/139

