### PR TITLE
Add `replaceNil(with:)` method

### DIFF
--- a/Sources/SignalProtocol.swift
+++ b/Sources/SignalProtocol.swift
@@ -818,6 +818,26 @@ public extension SignalProtocol where Element: OptionalProtocol {
       }
     }
   }
+
+  /// Replace all `nil`-elements with the provided replacement.
+  public func replaceNil(with replacement: Element.Wrapped) -> Signal<Element.Wrapped, Error> {
+    return Signal { observer in
+      return self.observe { event in
+        switch event {
+        case .next(let element):
+          if let element = element._unbox {
+            observer.next(element)
+          } else {
+            observer.next(replacement)
+          }
+        case .failed(let error):
+          observer.failed(error)
+        case .completed:
+          observer.completed()
+        }
+      }
+    }
+  }
 }
 
 //  MARK: Utilities

--- a/Tests/ReactiveKitTests/SignalTests.swift
+++ b/Tests/ReactiveKitTests/SignalTests.swift
@@ -231,6 +231,12 @@ class SignalTests: XCTestCase {
     unwrapped.expectComplete(after: [1, 3])
   }
 
+  func testReplaceNil() {
+    let operation = Signal<Int?, TestError>.sequence(Array<Int?>([1, nil, 3, nil]))
+    let unwrapped = operation.replaceNil(with: 7)
+    unwrapped.expectComplete(after: [1, 7, 3, 7])
+  }
+
   func testCombineLatestWith() {
     let bob = Scheduler()
     let eve = Scheduler()


### PR DESCRIPTION
I've been finding myself wanting this convenience for a while. I believe it improves the readability of code that requires replacement of `nil` values with some kind of default.

## Before

```swift
someSignalThatReturnsAnOptional
    .map { $0 ?? DefaultValue } 
    .observeNext { … }
```

## After

```swift
someSignalThatReturnsAnOptional
    .replaceNil(with: DefaultValue)
    .observeNext { … }
```