### PR TITLE
Allow appending Disposables to a DisposeBag using +=

### DIFF
--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -214,6 +214,10 @@ public final class DisposeBag: DisposeBagProtocol {
   }
 }
 
+public func += (left: DisposeBag, right: Disposable) {
+  left.add(disposable: right)
+}
+
 public extension Disposable {
 
   public func dispose(in disposeBag: DisposeBagProtocol) {


### PR DESCRIPTION
This PR adds a new operator:

```swift
public func += (left: DisposeBag, right: Disposable) {
  left.add(disposable: right)
}
```

Given that this already exists for `CompositeDisposable` with `Disposable`, I think this is logical and consistent.