### PR TITLE
Added in-line binding convenience methods for Void-typed signals

### DIFF
--- a/Sources/Bindable.swift
+++ b/Sources/Bindable.swift
@@ -114,6 +114,51 @@ extension SignalProtocol where Error == NoError {
   }
 }
 
+extension SignalProtocol where Error == NoError, Element == Void {
+
+  /// Bind the receiver to the target using the given setter closure. Closure is
+  /// called whenever the signal emits `next` event.
+  ///
+  /// Binding lives until either the signal completes or the target is deallocated.
+  /// That means that the returned disposable can be safely ignored.
+  ///
+  /// - Parameters:
+  ///   - target: A binding target. Conforms to `Deallocatable` so it can inform the binding
+  ///  when it gets deallocated. Upon target deallocation, the binding gets automatically disposed.
+  /// Also conforms to `BindingExecutionContextProvider` that provides that context on which to execute the setter.
+  ///   - setter: A closure that gets called on each next signal event with the target.
+  /// - Returns: A disposable that can cancel the binding.
+  @discardableResult
+  public func bind<Target: Deallocatable>(to target: Target, setter: @escaping (Target) -> Void) -> Disposable
+    where Target: BindingExecutionContextProvider
+  {
+    return bind(to: target, context: target.bindingExecutionContext, setter: setter)
+  }
+
+  /// Bind the receiver to the target using the given setter closure. Closure is
+  /// called whenever the signal emits `next` event.
+  ///
+  /// Binding lives until either the signal completes or the target is deallocated.
+  /// That means that the returned disposable can be safely ignored.
+  ///
+  /// - Parameters:
+  ///   - target: A binding target. Conforms to `Deallocatable` so it can inform the binding
+  ///  when it gets deallocated. Upon target deallocation, the binding gets automatically disposed.
+  ///   - context: An execution context on which to execute the setter.
+  ///   - setter: A closure that gets called on each next signal event with the target.
+  /// - Returns: A disposable that can cancel the binding.
+  @discardableResult
+  public func bind<Target: Deallocatable>(to target: Target, context: ExecutionContext, setter: @escaping (Target) -> Void) -> Disposable {
+    return take(until: target.deallocated).observeNext { [weak target] _ in
+      context.execute {
+        if let target = target {
+          setter(target)
+        }
+      }
+    }
+  }
+}
+
 /// Provides an execution context used to deliver binding events.
 public protocol BindingExecutionContextProvider {
 


### PR DESCRIPTION
In-line bindings for `Void`-typed signals pass the element to the setter, even though it's always `Void`:
```
signal.bind(to: self) { me, _ in // the second parameter is useless but needs to be there
    // do something
}
```

I added a specialization for the `Void` case that gets rid of the `element` parameter.