### PR TITLE
Add a couple of small conveniences

### DIFF
--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -46,4 +46,14 @@ extension Event {
       return true
     }
   }
+
+  /// Return `true` in case of `.failure` event.
+  public var isFailure: Bool {
+    switch self {
+    case .failed:
+      return true
+    default:
+      return false
+    }
+  }
 }

--- a/Sources/SignalProtocol.swift
+++ b/Sources/SignalProtocol.swift
@@ -1705,6 +1705,16 @@ extension SignalProtocol where Error == NoError {
   }
 }
 
+public extension SignalProtocol where Element == Bool {
+
+  /// Inverts the boolean value contained within the signal.
+  ///
+  /// - Returns: If the incoming value is `true`, emits `false` and vice versa.
+  public func not() -> Signal<Bool, Error> {
+    return map { $0 == false }
+  }
+}
+
 // MARK: Standalone functions
 
 /// Combine an array of signals into one. See `combineLatest(with:)` for more info.

--- a/Tests/ReactiveKitTests/Helpers.swift
+++ b/Tests/ReactiveKitTests/Helpers.swift
@@ -20,7 +20,7 @@ extension Event {
       return true
     case (.next(let left), .next(let right)):
       if let left = left as? Int, let right = right as? Int {
-        return left == right
+          return left == right
       } else if let left = left as? [Int], let right = right as? [Int] {
         return left == right
       } else if let left = left as? (Int?, Int), let right = right as? (Int?, Int) {
@@ -28,6 +28,8 @@ extension Event {
       } else if let left = left as? String, let right = right as? String {
         return left == right
       } else if let left = left as? [String], let right = right as? [String] {
+        return left == right
+      } else if let left = left as? Bool, let right = right as? Bool {
         return left == right
       } else {
         fatalError("Cannot compare that element type. \(left)")

--- a/Tests/ReactiveKitTests/SignalTests.swift
+++ b/Tests/ReactiveKitTests/SignalTests.swift
@@ -555,4 +555,10 @@ class SignalTests: XCTestCase {
 
     XCTAssertEqual(bob.numberOfRuns, 2)
   }
+
+  func testNot() {
+    let operation = Signal<Bool, NoError>.sequence([true, false, true])
+    let signal = operation.not()
+    signal.expectComplete(after: [false, true, false])
+  }
 }


### PR DESCRIPTION
This PR introduces two changes that I've found useful in my apps:

1. Add `Event.isFailure` - I found the need to distinguish failure events for materialised signals.
2. Add `Signal<Bool, E>.not()` to invert emitted boolean values.

I understand if this isn't a good fit - I know you prefer to keep things really small and maintainable.