### PR TITLE
Helpers to be used with `materialize()`

### DIFF
--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -46,4 +46,26 @@ extension Event {
       return true
     }
   }
+
+  /// Returns the next element, or nil if the event is not `.next`
+  public var element: Element? {
+    switch self {
+    case .next(let element):
+      return element
+
+    default:
+      return nil
+    }
+  }
+
+  /// Return the failed error, or nil if the event is not `.failed`
+  public var error: Error? {
+    switch self {
+    case .failed(let error):
+      return error
+
+    default:
+      return nil
+    }
+  }
 }

--- a/Sources/SignalProtocol.swift
+++ b/Sources/SignalProtocol.swift
@@ -1703,6 +1703,20 @@ extension SignalProtocol where Error == NoError {
   public func with<O: SignalProtocol>(latestFrom other: O) -> Signal<(Element, O.Element), O.Error> {
     return castError()._with(latestFrom: other, combine: { ($0, $1) })
   }
+
+  /// Returns an observable sequence containing only the unwrapped elements from `.next` events.
+  /// Usually used on the Signal resulting from `materialize()`.
+  /// - SeeAlso: `errors()`, `materialize()`
+  public func elements<U, E>() -> Signal<U, NoError> where Element == Event<U, E> {
+    return flatMap { $0.element }
+  }
+
+  /// Returns an observable sequence containing only the unwrapped errors from `.failed` events.
+  /// Usually used on the Signal resulting from `materialize()`.
+  /// - SeeAlso: `elements()`, `materialize()`
+  public func errors<U, E>() -> Signal<E, NoError> where Element == Event<U, E> {
+    return flatMap { $0.error }
+  }
 }
 
 // MARK: Standalone functions


### PR DESCRIPTION
I'm not sure if this is beginning to range outside the "small footprint" you're aiming for here, so no pressure to accept this PR.

This PR adds a properties to Event instances that help to unwrap `.next` elements and `.failed` errors. 

This in turn aids a couple of methods I've been using alongside `materialize()` in a situation where both my element and my error are of the same type:

```swift
func solveEquation(equation: String) -> Signal<Result, Result> {
   /// …
}

func set(equation: String) -> Signal<Result, NoError> {
     return solveEquation(variable: equation)
        .materialize()
        .elements()
}
```

It's probably of limited utility outside of this circumstance, but I thought I'd offer it up just in case.