### PR TITLE
Fix Swift Package Manager building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 
 script:
   - set -o pipefail && travis_retry xcodebuild -project ReactiveKit.xcodeproj -scheme ReactiveKit-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.0' test | xcpretty
-  - swift test --parallel
+  - swift test
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Package.swift
+++ b/Package.swift
@@ -2,5 +2,9 @@
 import PackageDescription
 
 let package = Package(
-    name: "ReactiveKit"
+    name: "ReactiveKit",
+	targets: [
+		.target(name: "ReactiveKit", path: "Sources"),
+		.testTarget(name: "ReactiveKitTests", dependencies: ["ReactiveKit"])
+	]
 )


### PR DESCRIPTION
The package manifest was not properly declared, as our sources are stored directly under `Sources` rather than under the expected location, `Sources/ReactiveKit`.

Can this be bundled into a release ASAP? It's blocking a number of Travis builds (Bond won't test successfully right now).