### PR TITLE
Declare a formal product for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,9 +2,12 @@
 import PackageDescription
 
 let package = Package(
-    name: "ReactiveKit",
-	targets: [
-		.target(name: "ReactiveKit", path: "Sources"),
-		.testTarget(name: "ReactiveKitTests", dependencies: ["ReactiveKit"])
-	]
+  name: "ReactiveKit",
+  products: [
+    .library(name: "ReactiveKit", targets: ["ReactiveKit"])
+  ],
+  targets: [
+    .target(name: "ReactiveKit", path: "Sources"),
+    .testTarget(name: "ReactiveKitTests", dependencies: ["ReactiveKit"])
+  ]
 )


### PR DESCRIPTION
This is causing Bond's tests to fail under Swift Package Manager. 

A new release of ReactiveKit will need to happen before https://github.com/ReactiveKit/Bond/pull/477 can be merged.