### PR TITLE
Add function and operator to insert an array of disposables into a dispose bag

### DIFF
--- a/Sources/Disposable.swift
+++ b/Sources/Disposable.swift
@@ -223,9 +223,20 @@ public final class DisposeBag: DisposeBagProtocol {
     disposables.append(disposable)
   }
 
+  /// Add the given disposables to the bag.
+  /// Disposables will be disposed when the bag is deallocated.
+  public func add(disposables: [Disposable]) {
+    disposables.forEach(add)
+  }
+
   /// Add a disposable to a dispose bag.
   public static func += (left: DisposeBag, right: Disposable) {
     left.add(disposable: right)
+  }
+
+  /// Add multiple disposables to a dispose bag.
+  public static func += (left: DisposeBag, right: [Disposable]) {
+    left.add(disposables: right)
   }
 
   /// Disposes all disposables that are currenty in the bag.


### PR DESCRIPTION
I found myself wanting to insert an array of `Disposable` tokens into a `DisposeBag`, so this PR introduces the `add(disposables: …)` and `+=` operator to allow this.