### PR TITLE
Overload `next` to not require passing `()` for `Void` types.

### DIFF
--- a/Sources/Observer.swift
+++ b/Sources/Observer.swift
@@ -118,3 +118,13 @@ public extension ObserverProtocol {
     return on
   }
 }
+
+public extension ObserverProtocol where Element == Void {
+
+  /// Convenience method to send `.next` event.
+  /// Overloaded to not require sending an instance of Void when calling.
+  public func next() {
+    next(())
+  }
+
+}


### PR DESCRIPTION
This should fix [#171](https://github.com/ReactiveKit/ReactiveKit/issues/171).