### PR TITLE
Fixes for Swift 4.1/Xcode 9.3b2

### DIFF
--- a/Sources/SignalProtocol.swift
+++ b/Sources/SignalProtocol.swift
@@ -791,6 +791,8 @@ public extension SignalProtocol where Element: Equatable {
   }
 }
 
+#if swift(>=4.1)
+#else
 public extension SignalProtocol where Element: OptionalProtocol, Element.Wrapped: Equatable {
   
   /// Emit first element and then all elements that are not equal to their predecessor(s).
@@ -798,6 +800,7 @@ public extension SignalProtocol where Element: OptionalProtocol, Element.Wrapped
     return distinct(areDistinct: !=)
   }
 }
+#endif
 
 public extension SignalProtocol where Element: OptionalProtocol {
 


### PR DESCRIPTION
This PR excludes the `distinct()` implementation when `Element: OptionalProtocol` under Swift 4.1 and later. It has been tested with Xcode 9.3 beta 2.