### PR TITLE
taken(until:) now terminates receiver when the provided signal completes

### DIFF
--- a/Sources/SignalProtocol.swift
+++ b/Sources/SignalProtocol.swift
@@ -774,9 +774,7 @@ public extension SignalProtocol {
     return Signal { observer in
       let disposable = CompositeDisposable()
 
-      disposable += signal.observe { event in
-        observer.completed()
-      }
+      disposable += signal.observeCompleted { observer.completed() }
 
       disposable += self.observe { event in
         switch event {

--- a/Tests/ReactiveKitTests/SignalTests.swift
+++ b/Tests/ReactiveKitTests/SignalTests.swift
@@ -217,6 +217,27 @@ class SignalTests: XCTestCase {
     let takenLast2 = operation.take(last: 2)
     takenLast2.expectComplete(after: [2, 3])
   }
+  
+  func testTakeUntil() {
+    let bob = Scheduler()
+    let eve = Scheduler()
+    
+    let operation = Signal<Int, TestError>.sequence([1, 2, 3]).observeIn(bob.context)
+    let interrupt = Signal<String, TestError>.sequence(["A", "B"]).observeIn(eve.context)
+    
+    let takeuntil = operation.take(until: interrupt)
+    
+    let exp = expectation(description: "completed")
+    takeuntil.expectAsyncComplete(after: [1, 2], expectation: exp)
+    
+    bob.runOne()
+    eve.runOne()            // Sends A, but not termination
+    bob.runOne()
+    eve.runRemaining()          // Sends B with termination
+    bob.runRemaining()
+    
+    waitForExpectations(timeout: 1, handler: nil)
+  }
 
 //  func testThrottle() {
 //    let operation = Signal<Int, TestError>.interval(0.4, queue: Queue.global).take(5)


### PR DESCRIPTION
# Reference
#186 

# Description
Prior to this change `take(until:)` would terminate for _any_ event that was sent on the provided signal. Now it only terminates when the provided signal completes.

Added Unit Test `testTakeUntil()` and verified that all tests pass with this change.

**Before change**
![Failed test BEFORE change](https://user-images.githubusercontent.com/3268395/38106167-cea2990c-3353-11e8-899e-ddff5fff3599.png)

**After change**
![Successful test AFTER change](https://user-images.githubusercontent.com/3268395/38106194-ddcfa7e4-3353-11e8-821b-8234941fc8e3.png)

**Test Results**
![screen shot 2018-03-29 at 1 22 37 pm](https://user-images.githubusercontent.com/3268395/38106351-520764bc-3354-11e8-8bed-7b2268d31f7e.png)

## Note : side effects
It's highly possible that this change will introduce behavior differences for clients who relied on _any_ event to terminate the receiver. But this previous behavior didn't match the provided function description.