### PR TITLE
Add required platforms to the package description

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,9 @@ import PackageDescription
 
 let package = Package(
     name: "ReactiveKit",
+    platforms: [
+        .macOS(.v10_9), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+    ],
     products: [
         .library(name: "ReactiveKit", targets: ["ReactiveKit"])
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "ReactiveKit",
     platforms: [
-        .macOS(.v10_9), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+        .macOS(.v10_11), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(name: "ReactiveKit", targets: ["ReactiveKit"])

--- a/README.md
+++ b/README.md
@@ -1054,7 +1054,7 @@ Trivial enough. Creating a `ConnectableSignal` with `ReplaySubject` ensures that
 
 We somehow need to convert connectable signal into a non-connectable one. In order to do that, we need to call connect at the right time and dispose at the right time. What are the right times? It is only reasonable - right time to connect is on the first observation and right time to dispose is when the last observation is disposed.
 
-In order to do this, we will keep a reference count. With each new observer, the count goes up, while on each disposal it goes down. We will connect when count goes from 0 to 1 and dispose when count goes from 1 to 0.  
+In order to do this, we will keep a reference count. With each new observer, the count goes up, while on each disposal it goes down. We will connect when count goes from 0 to 1 and dispose when count goes from 1 to 0.
 
 ```swift
 public extension ConnectableSignalProtocol {
@@ -1237,7 +1237,7 @@ extension UIViewController: LoadingStateListener {
 }
 ```
 
-Notice that `LoadingStateListener` gets `ObservedLoadingState` instead of `LoadingState`. The difference between the two is that the former has one additional state: `.reloading`. ReactiveKit will automatically convert subsequent `.loading` states into `.reloading` states so that you can potentially act differently in those two cases. 
+Notice that `LoadingStateListener` gets `ObservedLoadingState` instead of `LoadingState`. The difference between the two is that the former has one additional state: `.reloading`. ReactiveKit will automatically convert subsequent `.loading` states into `.reloading` states so that you can potentially act differently in those two cases.
 
 Now that we have a loading state listener, we can convert any loading signal into a regular safe signal by consuming its loading state by the listener:
 
@@ -1250,7 +1250,7 @@ fetchImage
     }
 ```
 
-Exciting! Operator `consumeLoadingState` takes the loading state listener and updates it each time a state is produced by the loading signal. It returns a safe signal of loading values, i.e. it unwraps the underlying value from the `.loaded` state. In our example that would be `SafeSignal<UIImage>` which we can then bind to our image view and update its content. 
+Exciting! Operator `consumeLoadingState` takes the loading state listener and updates it each time a state is produced by the loading signal. It returns a safe signal of loading values, i.e. it unwraps the underlying value from the `.loaded` state. In our example that would be `SafeSignal<UIImage>` which we can then bind to our image view and update its content.
 
 #### Transforming loading signals
 
@@ -1277,7 +1277,7 @@ class UserService {
     let user: LoadingProperty<User, ApplicationError>
 
     init(_ api: API) {
-        
+
         user = LoadingProperty {
             api.fetchUser()
         }
@@ -1344,12 +1344,12 @@ All you have to provide to the operator is the signals and a closure that maps t
 
 ## Requirements
 
-* iOS 8.0+ / macOS 10.9+ / tvOS 9.0+ / watchOS 2.0+
+* iOS 8.0+ / macOS 10.11+ / tvOS 9.0+ / watchOS 2.0+
 * Xcode 10.2
 
 or
 
-* Linux + Swift 5.0 
+* Linux + Swift 5.0
 
 ## Installation
 

--- a/ReactiveKit.podspec
+++ b/ReactiveKit.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/DeclarativeHub/ReactiveKit.git", :tag => "v3.10.0" }
 
   s.ios.deployment_target       = '8.0'
-  s.osx.deployment_target       = '10.9'
+  s.osx.deployment_target       = '10.11'
   s.watchos.deployment_target   = '2.0'
   s.tvos.deployment_target      = '9.0'
 


### PR DESCRIPTION
This also bumps the minimum required macOS version to 10.11 (which is the same as Bond). I think it's time - there's not really any way to reliably test this code all the way back to 10.9 anymore, is there?