### PR TITLE
Add prepend function for signals with Void element

### DIFF
--- a/Sources/SignalProtocol+Transforming.swift
+++ b/Sources/SignalProtocol+Transforming.swift
@@ -154,3 +154,10 @@ extension SignalProtocol {
         return scan(nil) { (pair, next) in (pair?.1, next) }.ignoreNils()
     }
 }
+
+extension SignalProtocol where Element == Void {
+
+    public func prepend() -> Signal<Void, Error> {
+        return prepend(())
+    }
+}

--- a/Sources/SignalProtocol+Transforming.swift
+++ b/Sources/SignalProtocol+Transforming.swift
@@ -158,6 +158,10 @@ extension SignalProtocol {
 extension SignalProtocol where Element == Void {
 
     public func prepend() -> Signal<Void, Error> {
-        return prepend(())
+        prepend(())
+    }
+
+    public func append() -> Signal<Void, Error> {
+        append(())
     }
 }


### PR DESCRIPTION
# Motivation
The existing `prepend` and `append` functions requires passing an instance of the `Element` type, which leads to the following code when the `Element` is `Void`:
```swift
var mySignal: Signal<Void, Never>()
...
mySignal.prepend(()) // we have to pass () to avoid compilation error
mySignal.append(()) // we have to pass () to avoid compilation error
```

that seems unnecessary as all instances of `Void` as the same.

# Change
I've added a specialized extension with an overload for the `prepend` and `append` functions. It will allow calling them without passing any parameters.

```swift
var mySignal: Signal<Void, Never>()
...
mySignal.prepend() 
mySignal.append() 
```

# Compatibility
This change is strictly additive and is fully compatible with existing code.

# Tests
On a local run all tests were passed successfully ✅